### PR TITLE
refactor datascience shiny and package services pages

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -246,3 +246,10 @@ iframe.talk {
 .shiny-caption {
     font-size: 1em;
 }
+
+.offering {
+    background-color: RGBA(17, 163, 165, 0.25) !important;
+    border-radius: 20px;
+    margin: 1em 0; 
+    padding: 1em 1.5em;
+}

--- a/content/services/advocacy.md
+++ b/content/services/advocacy.md
@@ -13,14 +13,46 @@ blendMode: 'hero-image-blend-color-burn'
 
 A longer term solution to getting access to RSE skills where they don't yet exist is to campaign for them! I can help with most forms of advocacy, from motivating talks to help with writing white papers or proposals.
 
-## Talks
+{{< offering >}}
 
-### useR!2020 Keynote: Computational Reproducibility, from Theory to Practice
+## What I offer
+
+* Motivational talks, seminars, interviews or panel appearances on the topics of:
+    - The importance of RSE in academia.
+    - Reproducible Research (especially in R).
+    - Experiences working as an independent but academia adjacent RSE consultant.
+* Contributing blogpost on similar topics.
+* Help with writing RSE work into grants.
+* Proposals or whitepapers promoting the concept of RSE.
+
+{{< /offering >}}
+
+## Why bother?
+
+Recognition of the importance of Research Software Engineering is slowly but surely spreading beyond the UK with many other countries promoting the role in academia. For example, this 2019 European Union white paper by the Open Science Monitor on  [Recognising the Importance of Software in Research – Research Software Engineers
+(RSEs), a UK Example](https://ec.europa.eu/info/sites/default/files/research_and_innovation/importance_of_software_in_research.pdf). Similar conclusions (among others) were drawn in the UK in the extremely thorough [Goldacre Review](https://www.goldacrereview.org/) into how the efficient and safe use of health data for research and analysis can benefit patients and the healthcare sector. While top down pressure is important, bottom up demand for RSE support is also an important part of the puzzle. The EU Open Science Monitor states that:
+
+{{< blockquote source="[Recognising the Importance of Software in Research – Research Software Engineers (RSEs), a UK Example - Open Science Monitor Case Study](https://ec.europa.eu/info/sites/default/files/research_and_innovation/importance_of_software_in_research.pdf)">}}
+
+The advocacy campaign through which the group engaged higher education
+media outlets, such as speaking at conferences and the creation of regular blog posts
+and news articles, also helped to raise the awareness of the role of RSEs and the
+need to support them
+
+{{< /blockquote >}}
+
+
+## Why me?
+
+
+### Talks
+
+#### useR!2020 Keynote: Computational Reproducibility, from Theory to Practice
 
 {{< youtube id="KHMW8fV2NXo" title="useR! 2020: Keynote - Computational Reproducibility, from Theory to Practice (Anna Krystalli)" >}}
 
 
-### What Can RSEs Do For U?
+#### What Can RSEs Do For U?
 ##### 2019 BES Quantitative & Movement Ecology SIG Annual Meeting
 
 

--- a/content/services/data_science.md
+++ b/content/services/data_science.md
@@ -16,7 +16,27 @@ blendMode: 'hero-image-blend-color-burn'
 
 As modern research becomes increasingly computational, leveraging more diverse forms of data and employing programming for data wrangling, modelling and analysis across more domains, it begins to increasingly fits the definition of data science. 
 
+{{< offering >}}
 
+## What I offer
+
+* Project organisation for portability, transparency and orientation.
+* Code modularisation and function development.
+* Code Optimisation.
+* Code testing and validation.
+* Exception handling with actionable, human friendly user messages.
+* Documentation (function, long form).
+* Data cleaning, processing, munging validation and documentation.
+* Literate Programming, Report and manuscript writing in Rmarkdown or Quarto.
+* Setting you up to write your thesis in R using bookdown.
+* Dependency and computational environment management (including containerisation with Docker of Singularity).
+* Version control and transparent code sharing (publically or privately) through online repositories.
+* Continuous integration (for testing or automated documentation builds).
+* Packaging papers, code and data into Research Compendia.
+
+{{< /offering >}}
+
+## Why bother?
 
 The **open source statistical programming language R**, has a rich history in academia and is increasingly a tool of choice in data science due to its broad statistical capabilities and active community supporting a rich ecosystem of powerful and continuously evolving packages. 
 
@@ -24,7 +44,7 @@ Such blending of freely available programming and statistical capabilities means
 
 **This is where we come in!**
 
-
+## Why me?
 
 ### Data Science
 
@@ -39,19 +59,7 @@ from data cleaning, profiling and validation, data munging, data modelling, pred
 
 Ensuring transparency, robustness, efficiency and reproducibility is just as important. Our experience in Research Software Engineering means such considerations are baked in from the start for all our projects. We can also help with refactoring your own project code according to software engineering best practice.
 
-We can help with:
 
-
-* Project organisation for portability, transparency and orientation
-* Code modularisation and function development
-* Code Optimisation
-* Code testing and validation
-* Exception handling with actionable, human friendly user messages.
-* Documentation (function, long form)
-* Literate Programming and Report writing in Rmarkdown or Quarto
-* Dependency and computational environment management (including containerisation with Docker of Singularity)
-* Version control and transparent code sharing (publically or privately) through online repositories
-* Continuous integration (for testing or automated documentation builds)
 
 
 

--- a/content/services/digital-asset-mgmt.md
+++ b/content/services/digital-asset-mgmt.md
@@ -13,21 +13,38 @@ weight: 5
 
 Organising your team's digital research assets and developing convention on how they are produced, stored, catalogued, accessed and used can be critical to doing more with your team's code and data.
 
-Inspiration for this particular type of work was provided by the task a friend of mine was given on her first postdoc. She was effectively given the hard drive containing a former PhD student's work and told to figure out what's on it are and build on it (!).
 
-Clearly this is not an effective way to work, yet is still quite a typical predicament in academia. However, you can avoid this by taking the managements of digital research assets seriously from the start, on-boarding group members on best practices and expectations and set up effective off-borading procedures that ensure all digital assets produced are accessible, well documented and easily reusable.
 
-![](https://media2.giphy.com/media/5YiRHZtcSeiEyOpSV7/giphy.gif?cid=790b76115d2070523958673849c75d9e&rid=giphy.gif)
+{{< offering >}}
 
-## Organise your data, code and ways of working.
+## What I offer
 
-- Decide on a framework for storage, access, cataloguing and archiving of digital assets.
+
+I can help you organise your data, code and ways of working. Specifically, I can:
+
+- Help you decide on a framework for storage, access, cataloguing and archiving of digital assets.
 - Build convention on how they are produced and used.
 - Develop guidance on how you want your team to collaborate.
 - Document conventions, procedures, access to assets and asset metadata.
 - Develop on-boarding and off-boarding procedures.
+- Develop tools, templates and automation around your conventions and workflows.
 
-## The power of convention
+{{< /offering >}}
+
+
+
+
+
+
+## Why bother?
+
+
+Inspiration for this particular type of work was provided by the task a friend of mine was given on her first postdoc. She was effectively handed the hard drive containing a former PhD student's work and told to figure out what's on it are and build on it (!).
+
+Clearly this is not an effective way to work, yet is still quite a typical predicament in academia. However, you can avoid this by taking the management of your team's digital research assets seriously from the start, setting up protocols, on-boarding group members on best practices and expectations and setting up effective off-boarding procedures that ensure all digital assets produced by the team are accessible, well documented and easily reusable in the future.
+
+
+### The power of convention
 
 {{< blockquote source="**Jenny Bryan** on [Project-oriented workflows](https://www.tidyverse.org/articles/2017/12/workflow-vs-script/)">}}
 
@@ -35,24 +52,30 @@ It’s like agreeing that we will all drive on the left or the right. A hallmark
 
 {{< /blockquote >}}
 
-Wise words from Jenny Bryan there that can make a huge difference to your team's workflows. For example, agreeing on variable names across datasets, on file formats, file naming, folder structure and organisation can help interoperability of team mates work immensely. It can help team members navigate your team assets with ease...including their own work when they need to come back to it later on!
+Wise words from Jenny Bryan there that can make a huge difference to your team's workflows. For example, agreeing on variable names across datasets, on file formats, file naming, folder structure and organisation can increase interoperability of team mates work immensely. It can help team members navigate team digital assets with ease...including their own work when they need to come back to it later on!
 
-## Documentation = the heart of team practice.
+### Documentation = the heart of team practice
 
+Good documentation is imperative for putting convention into practice and ensuring team mates have access to information required to work with team assets, following the working practices you set. Documentation can take the form of simple READMEs, team wikis or full documentation websites using frameworks like `blogdown` or `bookdown`. 
 
-Good documentation is imperative to putting convention into practice and ensuring team mates have access to information on required to work with your team's assets, following the working practices you have set. Documentation can take the form of a simple READMEs, team wiki's or full documentation websites using frameworks like blogdown or bookdown. 
+It's important to provide the ability for team mates to suggest edits and guidance on how they contribute to documentation when things change or where missing details are identified. This ensures your docs are living document that evolve with your team and practices and make team mates feel like active participants.
 
-It's important to provide the ability for team mates to suggest edits and guidance on how they can add to documentation when things change or where missing details are identified to both ensure your docs are a living document that evolevs with your team and practices and make team mates feel like active participants.
+Shared docs are also a great way to practice activities like collaborative content creation and editing, version control and content reviewing.
 
-Shared docs are also a great  way to practice activities like collaborative content creation, version control and content reviewing.
-
-## Tools, Templating and automation
+### Tools, Templating and automation
 
 The powerful thing about developing and documenting convention is that it allows you to build tools, templates and automation around it!
 
-From checklists, GitHub Issue and Pull Request templates to guide the team through actions, parametarised Rmarkdown or Quarto reports to reusable processing or analysis pipelines, consistent ways of working and producing digital assets can make their reuse much easier.
+From checklists, GitHub Issue and Pull Request templates to guide the team through actions, parametarised Rmarkdown or Quarto reports to reusable processing or analysis pipelines, consistent ways of working and producing digital assets can make their interoperability and reuse much easier.
 
-Conversely templating and automation which includes guidance and important checks can make it easier to ensure conventions are followed!
+Conversely, templating and automation which includes guidance and important checks can make it easier to ensure conventions are followed!
 
 A great example of convention powering automation and templating is the [`usethis`](https://usethis.r-lib.org/) package. It's a veritable treasure trove for setting up the repetitive infrastructure and files an R package or project depends on. Another example is [`pkgreviewr`](https://docs.ropensci.org/pkgreviewr/), a package I developed to facilitate rOpenSci reviews through automation, templates and guidance.
 
+## Why me?
+
+I love tidying messy workflows!
+
+![](https://media2.giphy.com/media/5YiRHZtcSeiEyOpSV7/giphy.gif?cid=790b76115d2070523958673849c75d9e&rid=giphy.gif)
+
+I've also gained a lot experience working with researchers as well as within the Sheffield RSE team itself and rOpenSci in assessing, documenting and iterating over team procedures as new circumstances arise and team workflows mature. I've also had plenty of experience working with documentation frameworks, creating effective checklists and templates and building tools to automate repetitive actions.

--- a/content/services/package-dev.md
+++ b/content/services/package-dev.md
@@ -11,20 +11,33 @@ heroBackground: 'services/box.gif'
 blendMode: 'hero-image-blend-color-burn'
 ---
 
-**What if your code is something you or others might want to use?** Despite being historically underappreciated in academia, software is increasingly gaining recognition as an impactful and important research output. Whether as a dependency for other projects or something that has applicability for a wider community of users, bundling up your code into an R package is the best way to make your code more reusable, accessible and robust. 
+**What if your code is something you or others might want to reuse in other projects?** Despite being historically underappreciated in academia, software is increasingly gaining recognition as an impactful and important research output. Whether as a dependency for other projects or something that has applicability for a wider community of users, bundling up your code into an R package is the best way to make your code more reusable, accessible and robust. 
+
+
+{{< offering >}}
+
+## What I offer
+
+* Code modularisation, generalisation and function development.
+* Code testing and validation.
+* Runtime checks, assertions and exception handling with actionable, human friendly messages.
+* Documentation (functions, long form vignettes, websites)
+* Version control and transparent code sharing (publically or privately) through online repositories
+* Continuous integration  (for testing or automated documentation builds).
+
+{{< /offering >}}
+
+
+## Why bother?
 
 ### Benefits of R package structure
 
-Creating a package out of your code allows us to leverage R software development tools including tools for testing, documenting, distributing, maintaining and installing functionality. It can also contribute to reproducibility through formal package versioning.
+Creating a package out of your code allows us to leverage R software development tools including tools for testing, documenting, distributing, maintaining and installing functionality. Introducing testing builds confidence in your code and, in turn, in the validity of results generated with it. It can also contribute to reproducibility through formal code versioning. Overall, it makes it easier for code to be deployed and used by others, and represents a citable research output you can get formal credit for.
 
-### What we can offer
+## Why me?
 
-We can help in all aspects of package development, whether building functionality from scratch to your specification or refactoring your code into an R package. More specifically, we can implement:
+I can help in all aspects of package development, whether building functionality from scratch to your specification or refactoring your code into an R package. I've built a number of both public and custom private packages for clients as well as built up experience through handling R package software reviews for rOpenSci. Have a look at the [work portfolio page](/work/) for more examples of packages I've built or contributes to. I generally to best practice laid out in the [rOpenSci Developers Guide](https://devguide.ropensci.org/) which you can review to get an idea of the standard you can expect from packages I build.
 
 
-* Code modularisation, generalisation and function development
-* Code testing and validation
-* Runtime checks, assertions and exception handling
-* Documentation (functions, long form vignettes, websites)
-* Version control and transparent code sharing (publically or privately) through online repositories
-* Continuous integration
+
+

--- a/content/services/shiny_web_apps.md
+++ b/content/services/shiny_web_apps.md
@@ -14,13 +14,34 @@ blendMode: 'hero-image-blend-color-burn'
 Shiny is an R package that makes it easy to build interactive web apps straight from R. You can host standalone apps on a webpage or embed them in R Markdown documents or build dashboards. Shiny apps can be themed to match your institutional, funder or project branding and can be extended with any number of functionalities through htmlwidgets, and JavaScript. actions.
 
 
+{{< offering >}}
+
+## What I offer
+
+- Development of shiny app or refactoring and optimisation of prototypes.
+- Testing of server and UI code.
+- Modularising and generalising shiny code.
+- Theming your shiny app (with brand colours and/or logos).
+- Packaging shiny apps as packages using the `golem` framework.
+- Advice and help with deployment.
+
+{{< /offering >}}
+
+## Why bother?
+
 #### Shiny apps are a great option if you want to allow others to:
 
 * **Explore a dataset** a shiny app can be especially useful if you have a large data set you'd like to allow users to explore. From raw data, visualisations or tables of statistical summaries, variable covariances, missing data characteristics or maps of spatial data, shiny apps can provide a much more user friendly exploration interface to data than, for example, a static Rmarkdown report, which can quickly become unwieldy with lots of data and properties to report. You can also allow users to add functionality to extract data.
 * **Explore the behaviour of models**: whether an analytical model, a machine learning model or a simulation, shiny apps are also a great way of allowing using to explore a model's input or parameter space and the resulting outputs, bringing your model to life! Such apps can also be excellent companion outputs to published research, allowing you to present additonal research results not able to be including in a given research paper.
 - **Teaching**: following on from the last two examples, shiny apps are a great teaching aid, enabling interactivity with data and concepts.
 
-I can help you with designing your app, building it an app from scratch, refactoring analysis code into a shiny app or refactoring a prototype app into a production level application, complete with theming and functionality tests.
+
+## Why me?
+
+Building or refactoring Shiny apps is one of my favourite type of projects and I've built a number of them by now, including for clients as an RSE, which you can find in the wild. Have a look at the [Shiny Apps](/work/shiny-apps/) page in my work portfolio for more details on specific apps and links to live apps and their code.
+
+I can help you design your app, build an app from scratch, refactor analysis code into a shiny app or refactor a prototype app into a production level application, complete with theming and functionality tests.
+
 
 ### Hosting and Deployment
 

--- a/content/services/training.md
+++ b/content/services/training.md
@@ -13,11 +13,36 @@ blendMode: 'hero-image-blend-color-burn'
 
 While access to an RSE to help with your R workflows can be useful, **it's even better to equip your team with skills to follow best practice in their own work from the start**.
 
-Such capacity building of researchers was one of my favourite parts of being an RSE. I find it most rewarding to see people's reactions when they realise the power of R and associated ecosystem of tools and of following best practice in code development and research data management. From full day to multi-day courses, shorter and more targeted workshops and seminars or hackathons, **I can help your team identify and get access to the training they need to get the most out of working with research code and data**.
+{{< offering >}}
+
+## What I offer
+
+* Course development or augmentation of existing materials according to your participants needs.
+* I specialise in teaching R, particularly Reproducible Research in R from a Research Software Engineering, which also includes topics like version control and `git`.
+* Targeted training activities that are relevant to participant's domain and workflows. 
+* Code along training, where I code and participants follow.
+* Remote or in-person teaching.
+* Delivery on Rstudio cloud for better control of computational environment.
+* Course materials websites available beyond the course, inclusing full setup instructions on participant's own systems. 
+* Interactive materials using the [`learnr`](https://rstudio.github.io/learnr/) package.
+* Development and delivery of hackathons, especially [ReproHacks](https://www.reprohack.org/)
+
+{{< /offering >}}
+
+## Why bother?
+
+It's much better to set your team up following best practice from the start. New PhD students especially can waste a lot of time trying to figure things out on their own, **often unaware of how much simpler and more effective their scientific code and data workflows could be if they knew a bit more about their tools and had some guidance on the most effective way to use them**. Once (non best practice) habits form, it's also often harder to motivate folks to invest in changing them. That's why I've found working with PhD students especially fruitful. Having said that, **it's never too late to learn the full power of your tools and better ways of working** and I've worked with many enthusiastic participants at all career stages!
+
+
+## Why me? 
+
+**Capacity building of researchers continues to be my favourite part of being an RSE.** I find it most rewarding to see people's reactions when they realise the power of R and associated ecosystem of tools and of following best practice in code development and research data management. I'm a Certified Software Carpentries instructor and have had a lot of experience by now developing and delivering creative training courses. From full day to multi-day courses, shorter and more targeted workshops and seminars or hackathons, **I can help your team identify and get access to the training they need to get the most out of working with research code and data**.
+
+## Examples of training I offer
 
 All examples of training materials below can be updated with newer information or modified to suit your specific needs. And of course, **I am always interested in developing something new** so please get in touch so we can discuss your needs!
 
-## Courses
+### Courses
 
 I have developed and taught a number of full to multi day courses. Here are a couple of examples of the types of courses I like to teach. 
 
@@ -65,7 +90,7 @@ The course covers:
 {{< /detail-tag >}}
 
 
-## Workshops
+### Workshops
 
 Depending on the time available for training, a shorter workshop on a specific topic might be more appropriate. Here's a few examples of workshops I've developed and delivered in response to client requests.
 
@@ -116,7 +141,7 @@ By the end of the workshop, you should be able to:
 {{< /detail-tag >}}
 
 
-## Seminars
+### Seminars
 
 Perhaps you just want someone to speak about best practice when working with research code and data in R! I've given many talks on topics regarding research reproducibility (have a look at our page on [advocacy services]({{< ref "/services/advocacy" >}}) for more details), but here's an example of the most well rounded talk on the topic.
 
@@ -132,7 +157,7 @@ I've given this talk a number of times and continue to update it every time. A [
 
 {{< /detail-tag >}}
 
-## Hackathons
+### Hackathons
 
 I've been involved in many hackathons, both as participant and organiser, and find them extermely effective and productive learning environments. Whatever the learning experience you want to create and topic you want to base your hackathon around, I can help you design and facilitate all aspects of it.
 

--- a/layouts/shortcodes/offering.html
+++ b/layouts/shortcodes/offering.html
@@ -1,0 +1,3 @@
+<div class="offering">
+    {{ .Inner | markdownify }}
+</div>

--- a/resources/_gen/assets/scss/scss/style.scss_5ad6f408b0e3e473c748aac88af0ea18.content
+++ b/resources/_gen/assets/scss/scss/style.scss_5ad6f408b0e3e473c748aac88af0ea18.content
@@ -6345,4 +6345,10 @@ iframe.talk {
 .shiny-caption {
   font-size: 1em; }
 
+.offering {
+  background-color: RGBA(17, 163, 165, 0.25) !important;
+  border-radius: 20px;
+  margin: 1em 0;
+  padding: 1em 1.5em; }
+
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
Following @maelle's review, I'm attempting to standardise services pages format and list offering quickly.